### PR TITLE
Fixes issue 48

### DIFF
--- a/opam
+++ b/opam
@@ -3,6 +3,7 @@ maintainer: "contact@ocamlpro.com"
 homepage: "http://www.typerex.org/ocaml-top.html"
 license: "GPL 3"
 build: [
+  ["ocp-build" "-init"]
   ["ocp-build" "-scan"]
   ["ocp-build" "ocaml-top"]
 ]


### PR DESCRIPTION
Needed because of ocp-build changes

Namely the in ocp-build-1.99.8-beta the options `-init` and `-scan` can not be used together.
And `-scan` is the one doing the real work.
