### PR TITLE
Changes required when compiling with -safe-string

### DIFF
--- a/ocaml-top.opam
+++ b/ocaml-top.opam
@@ -7,6 +7,7 @@ homepage: "http://www.typerex.org/ocaml-top.html"
 dev-repo: "https://github.com/OCamlPro/ocaml-top.git"
 bug-reports: "https://github.com/OCamlPro/ocaml-top/issues"
 license: "GPL-3"
+available: [ "ocaml-version" {>= "4.02.0"} ]
 build: ["jbuilder" "build" "-p" name]
 depends: [
   "jbuilder"

--- a/src/tools.ml
+++ b/src/tools.ml
@@ -92,8 +92,7 @@ module File = struct
         if size > Sys.max_string_length then
           failwith "Maximum file size exceeded";
         let ic = open_in_bin filename in
-        let buf = String.create size in
-        really_input ic buf 0 size;
+        let buf = really_input_string ic size in
         close_in ic;
         buf
       with

--- a/src/top.ml
+++ b/src/top.ml
@@ -82,7 +82,7 @@ let receive_event t f =
    Windows: we read from the ocaml process manually with a dedicated thread *)
 let reader_thread fdescr receive_from_main_thread build_response t =
   let buf_len = 4096 in
-  let buf = String.create buf_len in
+  let buf = Bytes.create buf_len in
   let rec loop () =
     if t.status = Dead then
       (Tools.debug "Ocaml process %d dead, reader thread terminating" t.pid;
@@ -90,7 +90,7 @@ let reader_thread fdescr receive_from_main_thread build_response t =
     try
       let nread = Unix.read fdescr buf 0 buf_len in
       if nread <= 0 then Thread.exit ();
-      let response = String.sub buf 0 nread in
+      let response = Bytes.sub_string buf 0 nread in
       (* Tools.debug "Incoming response from ocaml: %d %s" nread response; *)
       if t.status = Dead then
         (Tools.debug "OCaml process marked as dead, terminating reader thread";

--- a/src/topUi.ml
+++ b/src/topUi.ml
@@ -92,10 +92,7 @@ let display_stdout top response =
         let line =
           if offset >= 1024 then ""
           else if offset + String.length line <= 1024 then line
-          else
-            let s = String.sub line 0 (1024 - offset) in
-            String.blit "..." 0 s (1024 - offset - 3) 3;
-            s
+          else (String.sub line 0 (1024 - offset - 3) ^ "...")
         in
         insert_top ~tags:[OBuf.Tags.stdout] top top.stdout_mark line;
         if rest <> [] then


### PR DESCRIPTION
Minimal changes required to compile `ocaml-top` under OCaml version 4.06.0

Whether this is worth a version bump, it is not for me to say.