### PR TITLE
Fix build with recent OCaml versions (including 5.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,6 @@ ocaml-top
 
 A simple cross-platform OCaml code editor built for top-level evaluation.
 
-# DEPRECATION NOTICE
-
--------------------------------------------------------------------------
-
-This project is not maintained anymore.
-
-If you think this project should keep being maintained:
-
-* external contributions are welcome to fix issues and add new features ;
-
-* maintenance by OCamlPro's engineers can be funded by external entities.
-
-In both cases, since we are not watching the project anymore, contact
-us by mail at contact@ocamlpro.com!
-
--------------------------------------------------------------------------
-
 ## Features
 
 * Full functionality on Windows

--- a/ocaml-top.opam
+++ b/ocaml-top.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-version: "1.2.0"
+version: "1.2.1"
 maintainer: "contact@ocamlpro.com"
 authors: "Louis Gesbert <louis.gesbert@ocamlpro.com>"
 license: "GPL-3.0-only"
@@ -7,13 +7,13 @@ tags: ["org:ocamlpro" "gui" "teaching" "toplevel"]
 homepage: "http://www.typerex.org/ocaml-top.html"
 bug-reports: "https://github.com/OCamlPro/ocaml-top/issues"
 depends: [
-  "ocaml" {>= "4.02.0"}
+  "ocaml" {>= "4.08.0"}
   "dune" {>= "1.10"}
-  "ocp-pp" {build}
+  "cppo" {build}
   "lablgtk3"
   "lablgtk3-sourceview3"
   "ocp-indent" {>= "1.8.1"}
-  "ocp-index" {>= "1.0.0"}
+  "ocp-index" {>= "1.3.4"}
 ]
 build: ["dune" "build" "-p" name]
 dev-repo: "git+https://github.com/OCamlPro/ocaml-top.git"

--- a/src/completion.ml
+++ b/src/completion.ml
@@ -178,7 +178,7 @@ let setup_completion index buf (view: GSourceView3.source_view) =
     (* ref needed for bootstrap (!) *)
     let provider_ref = ref None in
     let custom_provider : GSourceView3.custom_completion_provider =
-      object (self)
+      object (_self)
         method name = "Available library values"
         method icon =  None
         method populate context =
@@ -194,7 +194,7 @@ let setup_completion index buf (view: GSourceView3.source_view) =
         method activation = [`USER_REQUESTED] (* ;`INTERACTIVE] *)
         method info_widget _propal = None
         method update_info _propal _info = ()
-        method start_iter context _propal iter = false
+        method start_iter _context _propal _iter = false
         method activate_proposal propal iter =
           let pfxlen = iter#offset - (completion_start_iter iter)#offset in
           let text = propal#text in
@@ -250,11 +250,11 @@ let setup buf (view: GSourceView3.source_view) message =
       with Unix.Unix_error _ | Sys_error _ -> dirs
     in
     try
-      LibIndex.load (LibIndex.Misc.unique_subdirs dirs)
+      LibIndex.load ~qualify:false (LibIndex.Misc.unique_subdirs dirs)
     with e ->
       Tools.debug "Exception during LibIndex.load: %s"
         (Printexc.to_string e);
-      LibIndex.load []
+      LibIndex.load ~qualify:false []
   in
   if Cfg.os <> Windows || Tools.debug_enabled then (
     (* Enable only for debug at the moment:

--- a/src/gui.ml
+++ b/src/gui.ml
@@ -320,7 +320,7 @@ module Dialogs = struct
   type 'a cps = ('a -> unit) -> unit
 
   let choose_file ~parent action ?(cancel = fun () -> ()) k =
-    let title, button_label = match action with
+    let title, _button_label = match action with
       | `OPEN -> "Please choose file to load", "Load"
       | `SAVE -> "Please choose file to save to", "Save"
     in

--- a/src/main.ml
+++ b/src/main.ml
@@ -104,14 +104,14 @@ module TopActions = struct
     match top.TopUi.process with Some process -> Top.kill process
                                | None -> ()
 
-  let clear top buf =
+  let clear top _buf =
     top.TopUi.buffer#delete
       ~start:top.TopUi.buffer#start_iter
       ~stop:top.TopUi.buffer#end_iter;
 end
 
 module UIActions = struct
-  let zoom value top_view src_view top buf =
+  let zoom value top_view src_view _top buf =
     let font = GPango.font_description_from_string !Cfg.font in
     let size = max 6 @@ min 24 @@ font#size / Pango.scale +  value in
     font#modify ~size:(size * Pango.scale) ();
@@ -266,7 +266,7 @@ let _ =
     if Cfg.os = Cfg.Windows then
       let gtkrc = Filename.concat !Cfg.datadir "gtkrc" in
       (try Glib.setenv "GTK_PATH" !Cfg.datadir true with Not_found -> ());
-      if Sys.file_exists gtkrc then GtkMain.Rc.parse gtkrc
+      if Sys.file_exists gtkrc then GtkMain.Rc.parse ~file:gtkrc
   in
   let main_window = Gui.main_window ()
   in

--- a/src/ocamlBuffer.ml
+++ b/src/ocamlBuffer.ml
@@ -129,7 +129,7 @@ module Tags = struct
     (fun t ->
       try Some (Hashtbl.find reverse t#get_oid) with
       | Not_found -> None),
-    fun obuf n ->
+    fun _obuf n ->
       update_if_font_changed ();
       try Hashtbl.find indent_tags n with
       | Not_found ->
@@ -348,7 +348,7 @@ let trigger_reindent ?cont t reindent_needed =
   | current ->
     t.need_reindent <- reindent_max current reindent_needed
 
-let raw_contents buf = buf.gbuffer#get_text ()
+let _raw_contents buf = buf.gbuffer#get_text ()
 
 let get_indented_text ~start ~stop buf =
   let indent_at it =
@@ -370,7 +370,7 @@ let get_indented_text ~start ~stop buf =
         if s#offset >= stop#offset then stop else s
       in
       if not start#ends_line then
-        for i = 1 to indent_at start do Buffer.add_char out ' ' done;
+        for _i = 1 to indent_at start do Buffer.add_char out ' ' done;
       Buffer.add_string out (buf.gbuffer#get_text ~start ~stop ());
       get_lines stop
   in

--- a/src/top.ml
+++ b/src/top.ml
@@ -42,7 +42,7 @@ type t = {
 
 let set_status t st = t.status <- st; t.status_change_hook t
 
-exception Not_running
+(* exception Not_running *)
 
 let main_thread = Thread.self ()
 
@@ -228,7 +228,7 @@ let start schedule response_handler status_hook =
   (* Wait for the first prompt to set the status to "Ready" and accept
      commands *)
   t.receive_hook <-
-    Some (await_full_response @@ fun response ->
+    Some (await_full_response @@ fun _response ->
         t.receive_hook <- None;
         set_status t Ready);
   t

--- a/src/top.mli
+++ b/src/top.mli
@@ -40,7 +40,7 @@ type response =
     @param status_change_hook will be called whenever the status changes
 *)
 val start :
-  ((unit -> unit) -> 'a) ->
+  ((unit -> unit) -> unit) ->
   (response -> unit) ->
   (status -> unit) ->
   t

--- a/src/topUi.ml
+++ b/src/topUi.ml
@@ -333,7 +333,7 @@ Gtk-WARNING **: Allocating size to GtkImage 0x556f667effa0 without calling gtk_w
       top.buffer#delete ~start:iter ~stop:iter#forward_char
 
 let rec top_start ~init ~status_change_hook top =
-  let schedule f = GMain.Idle.add @@ fun () ->
+  let schedule f = ignore @@ GMain.Idle.add @@ fun () ->
       try f (); false with e ->
           Printf.eprintf
             "Error in toplevel interaction: %s%!" (Tools.printexc e);

--- a/src/topUi.mli
+++ b/src/topUi.mli
@@ -23,8 +23,8 @@ type top = private {
 val create_buffer: unit -> top
 
 val top_start:
-  init:(unit -> 'a) ->
-  status_change_hook:(Top.status -> 'b) ->
+  init:(unit -> unit) ->
+  status_change_hook:(Top.status -> unit) ->
   top
   -> unit
 


### PR DESCRIPTION
Update ocaml-top to build with recent OCaml versions (up to 5.0 included).
- use cppo instead of ocp-pp (not available on 4.11 and above)
- update to ocp-index 1.3.4 (new `~qualify` argument added to `LibIndex.load`, while not technically needed, this is more future-proof)
- minimum OCaml version explicitly set to 4.08, because of the change to ocp-index >= 1.3.4, which itself depends on ocaml >= 4.08 (P.S. : lablgtk3 needs OCaml >= 4.05, so 4.02 was too low anyways)
- silence some unused variables warnings by prepending _
- ignore the return value of `GMain.Idle.add`